### PR TITLE
Wait for confirmation to start breaks & working sessions

### DIFF
--- a/breaktime.html
+++ b/breaktime.html
@@ -43,6 +43,17 @@
         box-shadow: none;
       }
 
+      #start_break {
+        display: block;
+        margin: 20px auto;
+        padding: 10px;
+        font-size: 24pt;
+        border-radius: 15px;
+        border-color: #a46379;
+        background-color: #a46379;
+        color: white;
+      }
+
       #french {
         font-family: serif;
         background: #ffdf7c;
@@ -75,6 +86,7 @@
   </head>
   <body>
     <div id="time""></div>
+    <button id="start_break" onclick="startBreak()" style="display: none;">Click to<br />Start Break</button>
     <div id="french">
       <h3 id="word">Dummy French Word</h3>
       <p id="example">Dummy French Sentence</p>

--- a/breaktime.js
+++ b/breaktime.js
@@ -9,8 +9,6 @@ function getRandomInt(max) {
     return Math.floor(Math.random() * Math.floor(max));
 }
 
-var breakDuration = 10;
-
 function tElapsedToS(tstart) {
     return Math.round((Date.now() - tstart) / 1000);
 }
@@ -91,6 +89,15 @@ async function setup() {
     console.log(await chrome.storage.local.get("breaktimer"));
 }
 
+// only called when the user clicks the "Start Break" button
+function startBreak() {
+    status = "Relaxing";
+    tstart = Date.now();
+    chrome.storage.local.set({ breaktimer: { status: status, starttime: tstart } });
+    document.getElementById("start_break").style.display = 'none';
+    document.getElementById("time").innerHTML = secondsToString(breakDuration - tElapsedToS(tstart));
+}
+
 window.onload = function() {
     const func_opts = {
       AI_img: populate_ai_img,
@@ -107,6 +114,12 @@ window.onload = function() {
     setup();
 
     var countdown = window.setInterval(function () {
+        if (status == "Working") {
+            this.document.getElementById("time").innerHTML = "Still Working...";
+            this.document.getElementById("start_break").onclick = startBreak;
+            this.document.getElementById("start_break").style.display = 'block';
+            return;
+        }
         if (tElapsedToS(tstart) >= breakDuration) {
             window.clearInterval(countdown);
             this.document.getElementById("time").innerHTML = "Break Done!!!";

--- a/breaktime.js
+++ b/breaktime.js
@@ -73,13 +73,25 @@ function populate_french(display) {
     }
 }
 
-window.onload = function() {
-    chrome.storage.local.get('btdur', function(data) {
-        if (data.btdur !== undefined) {
-            breakDuration = data.btdur;
-        }
-    });
+var breakDuration = 10;
+var status = "Working";
+var tstart = Date.now();
 
+async function setup() {
+    ({ breaktimer: {duration: breakDuration} } = await chrome.storage.sync.get("breaktimer"));
+    ({ breaktimer: {status, starttime: tstart} } = await chrome.storage.local.get("breaktimer"));
+    if (status == "Relaxing") {
+        this.document.getElementById("time").innerHTML = secondsToString(breakDuration - tElapsedToS(tstart));
+    } else {
+        this.document.getElementById("time").innerHTML = "Still Working...";
+        this.document.getElementById("start_break").onclick = startBreak;
+        this.document.getElementById("start_break").style.display = 'block';
+    }
+    console.log(`status: ${status}, tstart: ${tstart}, breakDuration: ${breakDuration}`);
+    console.log(await chrome.storage.local.get("breaktimer"));
+}
+
+window.onload = function() {
     const func_opts = {
       AI_img: populate_ai_img,
       quote: populate_quotes,
@@ -92,18 +104,7 @@ window.onload = function() {
         });
     }
 
-    chrome.storage.sync.get('breaktimer', function(data) {
-        breakDuration = data.breaktimer.duration;
-    });
-    chrome.storage.local.set({'btdur': breakDuration}); // cache
-    // this.document.getElementById("break").play();
-
-    var tstart = Date.now();
-    chrome.storage.local.get('breaktimer', function(data) {
-        tstart = data.breaktimer.starttime;
-        this.document.getElementById("time").innerHTML = secondsToString(breakDuration - tElapsedToS(tstart));
-    });
-    this.document.getElementById("time").innerHTML = secondsToString(breakDuration - tElapsedToS(tstart));
+    setup();
 
     var countdown = window.setInterval(function () {
         if (tElapsedToS(tstart) >= breakDuration) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BreakTimer",
   "description": "Monitor how long you've been working to suggest break times",
-  "version": "1.1",
+  "version": "1.2",
   "permissions": [
     "activeTab",
     "tabs",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BreakTimer",
   "description": "Monitor how long you've been working to suggest break times",
-  "version": "1.2",
+  "version": "1.3",
   "permissions": [
     "activeTab",
     "tabs",

--- a/offscreen.js
+++ b/offscreen.js
@@ -9,4 +9,8 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     console.log(`alerting ${request.message}`);
     alert(request.message);
   }
+  if (request.action == "confirm") {
+    console.log(`confirming ${request.message}`);
+    sendResponse(confirm(request.message));
+  }
 });

--- a/popup.js
+++ b/popup.js
@@ -68,10 +68,11 @@ function updatelabels() {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  chrome.storage.local.get('btcache', function(data) {
-    if (data.btcache !== undefined) {
-      interval = data.btcache.interval;
-      duration = data.btcache.duration;
+
+  chrome.storage.sync.get('breaktimer', function(data) {
+    if (data.breaktimer !== undefined) {
+      interval = data.breaktimer.interval;
+      duration = data.breaktimer.duration;
     }
     updatelabels();
     inputinterval = document.getElementById("interval");
@@ -118,13 +119,6 @@ document.addEventListener('DOMContentLoaded', function () {
   for (var i = 0; i < divs.length; i++) {
     divs[i].addEventListener('click', click);
   }
-
-  chrome.storage.sync.get('breaktimer', function(data) {
-    interval = data.breaktimer.interval;
-    duration = data.breaktimer.duration;
-    chrome.storage.local.set({'btcache': {interval: interval,
-                                          duration: duration}});
-  });
 });
 
 // chrome.alarms.onAlarm.addListener(function (alarm) {
@@ -139,8 +133,6 @@ chrome.storage.onChanged.addListener(function (changes, areaname) {
     if (changes.breaktimer !== undefined) {
       interval = changes.breaktimer.newValue.interval;
       duration = changes.breaktimer.newValue.duration;
-      chrome.storage.local.set({'btcache': {interval: interval,
-                                            duration: duration}});
     }
   }
   if (areaname == "local") {

--- a/popup.js
+++ b/popup.js
@@ -85,25 +85,25 @@ document.addEventListener('DOMContentLoaded', function () {
                                             duration: duration}});
     }
     inputinterval.addEventListener("keyup", function(event) {
+      console.log(event.keyCode, event.key);
       // Number 13 is the "Enter" key on the keyboard
-      if (event.keyCode === 13) {
+      if ((event.keyCode === 13) || (event.key === 'Tab')) {  // TODO: tab doesn't work
         event.preventDefault();
         interval = parseFloat(inputinterval.value);
         updatesync();
 
         // correct alarm timer
-        chrome.storage.local.get('breaktimer', function(data) {
+        chrome.storage.local.get("breaktimer", function (data) {
           chrome.alarms.clear("alarm");
-          chrome.alarms.create("alarm",
-          {
-            when: interval*60*1000 + data.breaktimer.starttime
+          chrome.alarms.create("alarm", {
+            when: interval * 60 * 1000 + data.breaktimer.starttime,
           });
-        })
+        });
       }
     });
     inputduration.addEventListener("keyup", function(event) {
       // Number 13 is the "Enter" key on the keyboard
-      if (event.keyCode === 13) {
+      if ((event.keyCode === 13) || event.key == 'Tab') {
         event.preventDefault();
         duration = parseFloat(inputduration.value) * 60;
         updatesync();

--- a/service_worker.js
+++ b/service_worker.js
@@ -28,7 +28,7 @@ async function setupOffscreenDocument(path) {
   } else {
     creating = chrome.offscreen.createDocument({
       url: path,
-      reasons: ['AUDIO_PLAYBACK'],
+      reasons: ['AUDIO_PLAYBACK', 'LOCAL_STORAGE'],
       justification: 'Playback audio & alerts',
     });
     await creating;

--- a/service_worker.js
+++ b/service_worker.js
@@ -106,9 +106,6 @@ chrome.runtime.onInstalled.addListener(function() {
   });
   chrome.storage.local.set({breaktimer: {status: "idle",
                                          starttime: Date.now()} });
-  chrome.storage.local.set({'btcache': {interval: interval,
-                                        duration: duration}});
-  chrome.storage.local.set({'btdur': duration}); // cache
   startWork();
 });
 


### PR DESCRIPTION
A number of changes wrapped up in this 1 PR:

* Refactoring
  * remove local storage cache in favor of just using sync
  * changed some callbacks to async awaits for readability
* Fix bug where, after "relax" finished, it would automatically start working again after ~30s due to chrome offscreen window automatically closing after 30s with the "AUDIO_PLAYBACK" reason ([documentation](https://developer.chrome.com/docs/extensions/reference/api/offscreen#reasons))
* Remove "auto-work" "feature"
* Instead of automatically starting the break, instead have a "confirm" dialogue, with "ok" starting the break and "cancel" delaying the start of the break until the "Start Break" button is pressed on the popup (which pops up in a background tab).